### PR TITLE
Inclusão do método .AddJsonObject()

### DIFF
--- a/Source/Otc.Extensions.Configuration/JsonObjectConfigurationProvider.cs
+++ b/Source/Otc.Extensions.Configuration/JsonObjectConfigurationProvider.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Configuration.Json;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Otc.Extensions.Configuration
+{
+    internal class JsonObjectConfigurationProvider : JsonConfigurationProvider
+    {
+        private readonly object configurationObject;
+
+        public JsonObjectConfigurationProvider(JsonConfigurationSource source, object configurationObject) : base(source)
+        {
+            this.configurationObject = configurationObject ?? throw new ArgumentNullException(nameof(configurationObject));
+        }
+
+        public override void Load()
+        {
+            var serializedObject = JsonConvert.SerializeObject(configurationObject);
+            var byteArray = Encoding.ASCII.GetBytes(serializedObject);
+            var memoryStream = new MemoryStream(byteArray);
+
+            Load(memoryStream);
+        }
+    }
+}

--- a/Source/Otc.Extensions.Configuration/JsonObjectConfigurationSource.cs
+++ b/Source/Otc.Extensions.Configuration/JsonObjectConfigurationSource.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+using System;
+
+namespace Otc.Extensions.Configuration
+{
+    internal class JsonObjectConfigurationSource : JsonConfigurationSource
+    {
+        private readonly object configurationObject;
+
+        public JsonObjectConfigurationSource(object configurationObject)
+        {
+            this.configurationObject = configurationObject ?? throw new ArgumentNullException(nameof(configurationObject));
+        }
+
+        public override IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            EnsureDefaults(builder);
+            return new JsonObjectConfigurationProvider(this, configurationObject);
+        }
+    }
+}

--- a/Source/Otc.Extensions.Configuration/Otc.Extensions.Configuration.csproj
+++ b/Source/Otc.Extensions.Configuration/Otc.Extensions.Configuration.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="Otc.Validations" Version="2.0.0" />
   </ItemGroup>
 

--- a/Source/Otc.Extensions.Configuration/OtcConfigurationBuilderExtensions.cs
+++ b/Source/Otc.Extensions.Configuration/OtcConfigurationBuilderExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Otc.Extensions.Configuration;
+
+namespace Microsoft.Extensions.Configuration
+{
+    public static class OtcConfigurationBuilderExtensions
+    {
+        /// <summary>
+        /// Adiciona um provedor de configuração baseado em um objeto ao configuration builder.
+        /// </summary>
+        /// <typeparam name="T">Classe do objeto de configuração.</typeparam>
+        /// <param name="builder">Configuration Builder.</param>
+        /// <param name="configurationObject">Objeto portador das configurações.</param>
+        /// <returns>Próprio configuration builder com o provedor adicionado.</returns>
+        public static IConfigurationBuilder AddJsonObject<T>(this IConfigurationBuilder builder, T configurationObject)
+            where T : class
+        {
+            return builder.Add(new JsonObjectConfigurationSource(configurationObject));
+        }
+    }
+}

--- a/Source/Otc.Extensions.Configuration/OtcConfigurationBuilderExtensions.cs
+++ b/Source/Otc.Extensions.Configuration/OtcConfigurationBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="builder">Configuration Builder.</param>
         /// <param name="configurationObject">Objeto portador das configurações.</param>
         /// <returns>Próprio configuration builder com o provedor adicionado.</returns>
-        public static IConfigurationBuilder AddJsonObject<T>(this IConfigurationBuilder builder, T configurationObject)
+        public static IConfigurationBuilder AddObject<T>(this IConfigurationBuilder builder, T configurationObject)
             where T : class
         {
             return builder.Add(new JsonObjectConfigurationSource(configurationObject));

--- a/Source/Otc.Extensions.Configuration/OtcConfigurationExtensions.cs
+++ b/Source/Otc.Extensions.Configuration/OtcConfigurationExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Otc.ComponentModel.DataAnnotations;
 using Otc.Validations;
 using System;
 using System.Collections.Generic;
-using Otc.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Otc.Extensions.Configuration


### PR DESCRIPTION
Inclusão de novo método de extensão para o Configuration Builder poder carregar um provedor de configuração baseado em um objeto.

Com essa alteração, já temos de imediato o benefício de carregar as configurações customizadas para o Serilog na ApiBoot.

Exemplo de utilização:
```C#
var serilogConfiguration = new ConfigurationBuilder()
    .AddJsonObject(Configuration.SafeGet<SerilogBase>())
    .Build();
```